### PR TITLE
refactor: replace gatsby-plugin-gitalk with direct gitalk usage

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,25 +151,6 @@ module.exports = {
         display: "swap",
       },
     },
-    {
-      resolve: `gatsby-plugin-gitalk`,
-      options: {
-        config: {
-          clientID: "541b66df2ca4fba90b0c",
-          clientSecret: "157f686855f29762873e8ce11e056f7397c58209",
-          repo: "blog",
-          owner: "izackwu",
-          admin: ["izackwu"],
-          pagerDirection: "first",
-          createIssueManually: true,
-          distractionFreeMode: false,
-          enableHotKey: true,
-          // fix CORS errors
-          proxy:
-            "https://cors-anywhere.azm.workers.dev/https://github.com/login/oauth/access_token",
-        },
-      },
-    },
     "gatsby-redirect-from",
     "gatsby-plugin-meta-redirect", // make sure this is always the last one
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,14 @@
 const _ = require("lodash")
+const crypto = require("crypto")
 const path = require(`path`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
+
+const GITALK_LABEL_MAX_LENGTH = 50
+
+function gitalkId(slug) {
+  if (slug.length <= GITALK_LABEL_MAX_LENGTH) return slug
+  return crypto.createHash("md5").update(slug).digest("hex")
+}
 
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
@@ -75,6 +83,7 @@ exports.createPages = async ({ graphql, actions }) => {
       component: pageTemplate,
       context: {
         slug: page.node.fields.slug,
+        gitalkId: gitalkId(page.node.fields.slug),
         dateFormat: dateFormat,
       },
     })
@@ -91,6 +100,7 @@ exports.createPages = async ({ graphql, actions }) => {
       component: blogPost,
       context: {
         slug: post.node.fields.slug,
+        gitalkId: gitalkId(post.node.fields.slug),
         previous,
         next,
         dateFormat: dateFormat,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "^5.1.3",
     "gatsby": "^4.2.0",
     "gatsby-plugin-feed": "^4.2.0",
-    "gatsby-plugin-gitalk": "^1.2.6",
+    "gitalk": "^1.8.0",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-manifest": "^4.2.0",
     "gatsby-plugin-meta-redirect": "^1.1.1",

--- a/scripts/migrate-gitalk-labels.sh
+++ b/scripts/migrate-gitalk-labels.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# One-time migration: add slug-based labels to existing Gitalk issues
+# so the standard gitalk library can find them.
+#
+# The old gatsby-plugin-gitalk (@suziwen/gitalk fork) matched issues by
+# searching the body for "Gitalk_<slug>". The standard gitalk library
+# matches by GitHub issue labels. This script bridges the gap.
+#
+# For slugs > 50 chars (GitHub label limit), we use an MD5 hash instead,
+# matching the logic in gatsby-node.js.
+
+set -euo pipefail
+
+REPO="izackwu/blog"
+MAX_LABEL_LENGTH=50
+
+gh api "repos/$REPO/issues?labels=Gitalk&state=all&per_page=100" --jq '
+  .[] | select(.body | test("Gitalk_")) |
+  {number, slug: (.body | capture("Gitalk_(?<id>[^ \\n]+)") | .id)} |
+  "\(.number)\t\(.slug)"
+' | while IFS=$'\t' read -r number slug; do
+  if [ ${#slug} -gt $MAX_LABEL_LENGTH ]; then
+    label=$(echo -n "$slug" | md5sum | cut -d' ' -f1)
+    echo "Issue #$number: slug '$slug' (${#slug} chars) -> MD5 label '$label'"
+  else
+    label="$slug"
+    echo "Issue #$number: label '$label'"
+  fi
+
+  gh api "repos/$REPO/issues/$number/labels" --method POST -f "labels[]=$label" --silent
+done
+
+echo "Done!"

--- a/src/components/gitalk/gitalk.js
+++ b/src/components/gitalk/gitalk.js
@@ -1,19 +1,42 @@
-import "@suziwen/gitalk/dist/gitalk.css"
+import "gitalk/dist/gitalk.css"
 import "./style-fix.scss"
 
-import Gitalk from "gatsby-plugin-gitalk"
-import React from "react"
+import React, { useEffect, useRef } from "react"
+import Gitalk from "gitalk"
 import * as styles from "./gitalk.module.scss"
 
+const gitalkConfig = {
+  clientID: "541b66df2ca4fba90b0c",
+  clientSecret: "157f686855f29762873e8ce11e056f7397c58209",
+  repo: "blog",
+  owner: "izackwu",
+  admin: ["izackwu"],
+  pagerDirection: "first",
+  createIssueManually: true,
+  distractionFreeMode: false,
+  enableHotKey: true,
+  proxy:
+    "https://cors-anywhere.azm.workers.dev/https://github.com/login/oauth/access_token",
+}
+
 const MyGitalk = ({ title, id }) => {
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.innerHTML = ""
+      const gitalk = new Gitalk({
+        ...gitalkConfig,
+        id,
+        title,
+      })
+      gitalk.render(containerRef.current)
+    }
+  }, [id, title])
+
   return (
     <div className={styles["gitalk"]}>
-      <Gitalk
-        options={{
-          id,
-          title,
-        }}
-      />
+      <div ref={containerRef} />
     </div>
   )
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -27,7 +27,7 @@ const BlogPostTemplate = ({ data, pageContext }) => {
           nextText={next && next.frontmatter.title + " →"}
         />
         {!post.frontmatter.noComments && (
-          <MyGitalk id={pageContext.slug} title={post.frontmatter.title} />
+          <MyGitalk id={pageContext.gitalkId} title={post.frontmatter.title} />
         )}
       </Main>
     </Layout>

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -21,7 +21,7 @@ const PageTemplate = ({ data, pageContext }) => {
           <div dangerouslySetInnerHTML={{ __html: page.html }} />
         </Page>
         {!page.frontmatter.noComments && (
-          <MyGitalk id={pageContext.slug} title={page.frontmatter.title} />
+          <MyGitalk id={pageContext.gitalkId} title={page.frontmatter.title} />
         )}
       </Main>
     </Layout>


### PR DESCRIPTION
## Summary
- Replace unmaintained `gatsby-plugin-gitalk` (which depends on `@suziwen/gitalk` fork pinned to React 16) with direct usage of the standard `gitalk` library
- The standard gitalk matches issues by GitHub label instead of body search, so add a `gitalkId` helper in `gatsby-node.js` that uses the slug as the label (or MD5 hash for slugs >50 chars, GitHub's label limit)
- Include a one-time migration script (`scripts/migrate-gitalk-labels.sh`) to add slug labels to all existing Gitalk issues

## Test plan
- [x] Verify comments load on a post with a short slug (e.g. `/posts/2023-12-03-a-year-of-change/`)
- [x] Verify comments load on a post with a long slug that uses MD5 (e.g. `/posts/2020-10-05-an-incomplete-guide-to-campus-recruitment-interviews/`)
- [x] Verify comments load on the About page (`/about/`)
- [ ] Verify creating a new comment works
- [ ] Verify the login flow (GitHub OAuth) works
- [x] Check that no errors appear in the browser console on a post page