### PR TITLE
refactor: migrate react-helmet to Gatsby Head API

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -142,7 +142,6 @@ module.exports = {
         icon: `static/tree.png`,
       },
     },
-    `gatsby-plugin-react-helmet`,
     `gatsby-plugin-sass`,
     {
       resolve: `gatsby-plugin-google-fonts`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "gatsby-plugin-manifest": "^5.16.0",
         "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-plugin-plausible": "^0.0.7",
-        "gatsby-plugin-react-helmet": "^6.16.0",
         "gatsby-plugin-sass": "^6.16.0",
         "gatsby-plugin-sitemap": "^6.16.0",
         "gatsby-redirect-from": "^1.3.0",
@@ -33,7 +32,6 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.0",
         "react-dom": "^18.2.0",
-        "react-helmet": "^6.1.0",
         "react-icons": "^4.12.0",
         "sass": "^1.77.0",
         "sharp": "^0.34.5"
@@ -8738,15 +8736,15 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
+      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
+        "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.2",
+        "es-abstract": "^1.24.1",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -8758,7 +8756,8 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0"
+        "math-intrinsics": "^1.1.0",
+        "safe-array-concat": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10967,22 +10966,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gatsby-plugin-react-helmet": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-6.16.0.tgz",
-      "integrity": "sha512-0iXshdRoPaeJ8xCTsBYTT6G7Txp9PcXDgotbzigdVGY6bXvFUSbEMFSVub7xtNKPX4LYnZkQxsjcOu0MXVFLuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13"
-      },
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next",
-        "react-helmet": "^5.1.3 || ^6.0.0"
       }
     },
     "node_modules/gatsby-plugin-sass": {
@@ -17227,27 +17210,6 @@
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
     "node_modules/react-icons": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -17276,15 +17238,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-side-effect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gatsby-plugin-manifest": "^5.16.0",
     "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-plausible": "^0.0.7",
-    "gatsby-plugin-react-helmet": "^6.16.0",
     "gatsby-plugin-sass": "^6.16.0",
     "gatsby-plugin-sitemap": "^6.16.0",
     "gatsby-redirect-from": "^1.3.0",
@@ -32,7 +31,6 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.0",
     "react-dom": "^18.2.0",
-    "react-helmet": "^6.1.0",
     "react-icons": "^4.12.0",
     "sass": "^1.77.0",
     "sharp": "^0.34.5"

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -1,16 +1,9 @@
 import React from "react"
-import Seo from "./seo"
 import * as styles from "./layout.module.scss"
 
-const Layout = ({ title, description, socialImage, children, meta }) => {
+const Layout = ({ children }) => {
   return (
     <div className={styles.layout}>
-      <Seo
-        title={title}
-        description={description}
-        meta={meta}
-        socialImage={socialImage}
-      />
       {children}
     </div>
   )

--- a/src/components/layout/seo/seo.js
+++ b/src/components/layout/seo/seo.js
@@ -1,17 +1,7 @@
-/**
- * SEO component that queries for data with
- *  Gatsby's useStaticQuery React hook
- *
- * See: https://www.gatsbyjs.org/docs/use-static-query/
- */
-
 import { graphql, useStaticQuery } from "gatsby"
-
-import { Helmet } from "react-helmet"
-import PropTypes from "prop-types"
 import React from "react"
 
-const Seo = ({ description, lang, meta, title, socialImage }) => {
+const Seo = ({ description, lang, title, socialImage }) => {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -31,77 +21,28 @@ const Seo = ({ description, lang, meta, title, socialImage }) => {
     `
   )
   const metaDescription = description || site.siteMetadata.description
-  // Twitter card only supports absolute URLs
   const metaImage = new URL(
     socialImage || site.siteMetadata.image,
     site.siteMetadata.siteUrl
   ).toString()
+  const language = lang || site.siteMetadata.language
 
   return (
-    <Helmet
-      htmlAttributes={{
-        lang: lang || site.siteMetadata.language,
-      }}
-      title={title}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
-      meta={[
-        {
-          name: `description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          property: `og:image`,
-          content: metaImage,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.siteMetadata.social.twitter,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: metaDescription,
-        },
-        {
-          name: `twitter:image`,
-          content: metaImage,
-        },
-      ].concat(meta)}
-    />
+    <>
+      <html lang={language} />
+      <title>{`${title} | ${site.siteMetadata.title}`}</title>
+      <meta name="description" content={metaDescription} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={metaDescription} />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content={metaImage} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:creator" content={site.siteMetadata.social.twitter} />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={metaDescription} />
+      <meta name="twitter:image" content={metaImage} />
+    </>
   )
-}
-
-Seo.defaultProps = {
-  lang: ``,
-  meta: [],
-  description: ``,
-}
-
-Seo.propTypes = {
-  description: PropTypes.string,
-  lang: PropTypes.string,
-  meta: PropTypes.arrayOf(PropTypes.object),
-  title: PropTypes.string.isRequired,
-  socialImage: PropTypes.string,
 }
 
 export default Seo

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -2,11 +2,12 @@ import Layout from "../components/layout"
 import Main from "../components/main"
 import Page from "../components/page"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 
 const NotFoundPage = () => {
   return (
-    <Layout title="404: Not Found">
+    <Layout>
       <Sidebar />
       <Main>
         <Page title="404: Not Found">
@@ -18,3 +19,5 @@ const NotFoundPage = () => {
 }
 
 export default NotFoundPage
+
+export const Head = () => <Seo title="404: Not Found" />

--- a/src/templates/archive.js
+++ b/src/templates/archive.js
@@ -3,13 +3,14 @@ import Main from "../components/main"
 import Page from "../components/page"
 import PostList from "../components/postlist"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 import { graphql } from "gatsby"
 
 const Archive = ({ data }) => {
   const posts = data.allMarkdownRemark.edges
   return (
-    <Layout title="Archive" description="本站所有文章，尽在此处，一览无余。">
+    <Layout>
       <Sidebar />
       <Main>
         <Page title="Archive" nopadding>
@@ -19,6 +20,12 @@ const Archive = ({ data }) => {
     </Layout>
   )
 }
+
+export default Archive
+
+export const Head = () => (
+  <Seo title="Archive" description="本站所有文章，尽在此处，一览无余。" />
+)
 
 export const query = graphql`
   query($dateFormat: String) {
@@ -40,5 +47,3 @@ export const query = graphql`
     }
   }
 `
-
-export default Archive

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -4,6 +4,7 @@ import MyGitalk from "../components/gitalk"
 import Pagination from "../components/pagination"
 import Post from "../components/post"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 import { graphql } from "gatsby"
 
@@ -12,11 +13,7 @@ const BlogPostTemplate = ({ data, pageContext }) => {
   const { previous, next } = pageContext
 
   return (
-    <Layout
-      title={post.frontmatter.title}
-      description={post.frontmatter.description || post.excerpt}
-      socialImage={post.frontmatter.image}
-    >
+    <Layout>
       <Sidebar toc={post.tableOfContents} />
       <Main>
         <Post post={post} />
@@ -35,6 +32,17 @@ const BlogPostTemplate = ({ data, pageContext }) => {
 }
 
 export default BlogPostTemplate
+
+export const Head = ({ data }) => {
+  const post = data.markdownRemark
+  return (
+    <Seo
+      title={post.frontmatter.title}
+      description={post.frontmatter.description || post.excerpt}
+      socialImage={post.frontmatter.image}
+    />
+  )
+}
 
 export const pageQuery = graphql`
   query BlogPostBySlug($slug: String!, $dateFormat: String) {

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -3,6 +3,7 @@ import Main from "../components/main"
 import MyGitalk from "../components/gitalk"
 import Page from "../components/page"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 import { graphql } from "gatsby"
 
@@ -10,11 +11,7 @@ const PageTemplate = ({ data, pageContext }) => {
   const page = data.markdownRemark
 
   return (
-    <Layout
-      title={page.frontmatter.title}
-      description={page.frontmatter.description || page.excerpt}
-      socialImage={page.frontmatter.image}
-    >
+    <Layout>
       <Sidebar />
       <Main>
         <Page title={page.frontmatter.title} image={page.frontmatter.image}>
@@ -29,6 +26,17 @@ const PageTemplate = ({ data, pageContext }) => {
 }
 
 export default PageTemplate
+
+export const Head = ({ data }) => {
+  const page = data.markdownRemark
+  return (
+    <Seo
+      title={page.frontmatter.title}
+      description={page.frontmatter.description || page.excerpt}
+      socialImage={page.frontmatter.image}
+    />
+  )
+}
 
 export const pageQuery = graphql`
   query PageBySlug($slug: String!) {

--- a/src/templates/post-list-paginated.js
+++ b/src/templates/post-list-paginated.js
@@ -3,18 +3,15 @@ import Main from "../components/main"
 import Pagination from "../components/pagination"
 import PostList from "../components/postlist"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 import { graphql } from "gatsby"
 
 const BlogIndex = ({ data, pageContext }) => {
   const posts = data.allMarkdownRemark.edges
   const { totalPage, currentPage } = pageContext
-  const description =
-    currentPage > 1
-      ? `本站文章列表：第 ${currentPage} 页，共 ${totalPage} 页。`
-      : ""
   return (
-    <Layout title="Posts" description={description}>
+    <Layout>
       <Sidebar />
       <Main>
         <PostList posts={posts} />
@@ -32,6 +29,15 @@ const BlogIndex = ({ data, pageContext }) => {
 }
 
 export default BlogIndex
+
+export const Head = ({ pageContext }) => {
+  const { totalPage, currentPage } = pageContext
+  const description =
+    currentPage > 1
+      ? `本站文章列表：第 ${currentPage} 页，共 ${totalPage} 页。`
+      : ""
+  return <Seo title="Posts" description={description} />
+}
 
 export const pageQuery = graphql`
   query($skip: Int!, $limit: Int!, $dateFormat: String) {

--- a/src/templates/tags-list.js
+++ b/src/templates/tags-list.js
@@ -2,6 +2,7 @@ import Layout from "../components/layout"
 import Main from "../components/main"
 import Page from "../components/page"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 import Tags from "../components/tags"
 import { graphql } from "gatsby"
@@ -11,10 +12,7 @@ const TagsPage = ({
     allMarkdownRemark: { group },
   },
 }) => (
-  <Layout
-    title="Tags"
-    description="本站文章的所有标签，以及标签所包含的文章数量。"
-  >
+  <Layout>
     <Sidebar />
     <Main>
       <Page title="Tags">
@@ -25,6 +23,13 @@ const TagsPage = ({
 )
 
 export default TagsPage
+
+export const Head = () => (
+  <Seo
+    title="Tags"
+    description="本站文章的所有标签，以及标签所包含的文章数量。"
+  />
+)
 
 export const pageQuery = graphql`
   query {

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -3,19 +3,17 @@ import Main from "../components/main"
 import Page from "../components/page"
 import PostList from "../components/postlist"
 import React from "react"
+import Seo from "../components/layout/seo"
 import Sidebar from "../components/sidebar"
 import { graphql } from "gatsby"
 
 const Tags = ({ pageContext, data }) => {
   const { tag } = pageContext
-  const { edges, totalCount } = data.allMarkdownRemark
+  const { edges } = data.allMarkdownRemark
   const tagHeader = `Tag: ${tag}`
 
   return (
-    <Layout
-      title={tagHeader}
-      description={`「${tag}」标签下共有 ${totalCount} 篇文章。`}
-    >
+    <Layout>
       <Sidebar />
       <Main>
         <Page title={tagHeader} nopadding>
@@ -27,6 +25,17 @@ const Tags = ({ pageContext, data }) => {
 }
 
 export default Tags
+
+export const Head = ({ pageContext, data }) => {
+  const { tag } = pageContext
+  const { totalCount } = data.allMarkdownRemark
+  return (
+    <Seo
+      title={`Tag: ${tag}`}
+      description={`「${tag}」标签下共有 ${totalCount} 篇文章。`}
+    />
+  )
+}
 
 export const pageQuery = graphql`
   query($tag: String, $dateFormat: String) {


### PR DESCRIPTION
## Summary
- Replace `gatsby-plugin-react-helmet` + `react-helmet` with Gatsby 5's built-in Head API
- Export `Head` function from all page templates and pages instead of using `<Seo>` inside `<Layout>`
- Simplify `Layout` component (no longer needs SEO props)

## Test plan
- [x] Verify `<title>` and meta tags render correctly on blog posts
- [x] Verify `<title>` and meta tags render correctly on pages (About, etc.)
- [x] Verify Open Graph tags work (check with browser dev tools or a link preview tool)
- [x] Verify `<html lang="zh">` is set correctly
- [x] View page source to confirm meta tags are in `<head>`