### PR TITLE
refactor: migrate Sass @import to @use and fix deprecated color functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10986,6 +10986,46 @@
         "sass": "^1.30.0"
       }
     },
+    "node_modules/gatsby-plugin-sass/node_modules/sass-loader": {
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+      "integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
+      "license": "MIT",
+      "dependencies": {
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "sass": "^1.3.0",
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/gatsby-plugin-sitemap": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-6.16.0.tgz",
@@ -18398,61 +18438,6 @@
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
-      }
-    },
-    "node_modules/sass-loader": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.5.2.tgz",
-      "integrity": "sha512-vMUoSNOUKJILHpcNCCyD23X34gve1TS7Rjd9uXHeKqhvBG39x6XbswFDtpbTElj6XdMFezoWhkh5vtKudf2cgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "sass": "^1.3.0",
-        "webpack": "^4.36.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "fibers": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/sass-loader/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/sass/node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prettier": "^3.3.0"
   },
   "overrides": {
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "sass-loader": "^16.0.0"
   },
   "homepage": "https://github.com/izackwu/gatsby-starter-breeze",
   "keywords": [

--- a/src/components/gitalk/gitalk.module.scss
+++ b/src/components/gitalk/gitalk.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .gitalk {
   padding-left: 35px;

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .layout {
   max-width: $max-two-column-width;

--- a/src/components/main/main.module.scss
+++ b/src/components/main/main.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .main {
   width: $main-container-width;

--- a/src/components/page/page.module.scss
+++ b/src/components/page/page.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .header {
   &__image {

--- a/src/components/pagination/pagination.module.scss
+++ b/src/components/pagination/pagination.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .pagination {
   padding: 20px 35px;

--- a/src/components/post/post.module.scss
+++ b/src/components/post/post.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .header {
   &__image {

--- a/src/components/postlist/postlist.module.scss
+++ b/src/components/postlist/postlist.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .postlist {
   > * {

--- a/src/components/sidebar/copyright/copyright.module.scss
+++ b/src/components/sidebar/copyright/copyright.module.scss
@@ -1,4 +1,4 @@
-@import "../../../scss/variables";
+@use "../../../scss/variables" as *;
 
 .copyright {
   padding: 20px 30px 0 20px;

--- a/src/components/sidebar/menu/menu.module.scss
+++ b/src/components/sidebar/menu/menu.module.scss
@@ -1,4 +1,5 @@
-@import "../../../scss/variables";
+@use "sass:color";
+@use "../../../scss/variables" as *;
 
 .menu {
   flex-grow: 1;

--- a/src/components/sidebar/sidebar.module.scss
+++ b/src/components/sidebar/sidebar.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .sidebar {
   position: sticky;

--- a/src/components/sidebar/sitemeta/sitemeta.module.scss
+++ b/src/components/sidebar/sitemeta/sitemeta.module.scss
@@ -1,4 +1,5 @@
-@import "../../../scss/variables";
+@use "sass:color";
+@use "../../../scss/variables" as *;
 
 .sitemeta {
   padding: 30px 28px 30px 20px;

--- a/src/components/sidebar/social-links/social-links.module.scss
+++ b/src/components/sidebar/social-links/social-links.module.scss
@@ -1,4 +1,4 @@
-@import "../../../scss/variables";
+@use "../../../scss/variables" as *;
 
 .social {
   width: 100%;

--- a/src/components/sidebar/toc/toc.module.scss
+++ b/src/components/sidebar/toc/toc.module.scss
@@ -1,4 +1,5 @@
-@import "../../../scss/variables";
+@use "sass:color";
+@use "../../../scss/variables" as *;
 
 .toc {
   border-radius: 5px;

--- a/src/components/tags/tags.module.scss
+++ b/src/components/tags/tags.module.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables";
+@use "../../scss/variables" as *;
 
 .tags {
   list-style: none;

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -1,5 +1,4 @@
 @charset "UTF-8";
 
-// @import "normalize-scss";
-@import "bootstrap/scss/bootstrap";
-@import "base/generic";
+@use "bootstrap/scss/bootstrap";
+@use "base/generic";

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,4 +1,6 @@
-/** 
+@use "sass:color";
+
+/**
  * Variables
  */
 
@@ -7,11 +9,11 @@ $color-accent: #177682;
 $back-container-background: #fcfcfc;
 $front-container-background: #ffffff;
 
-$dark-accent: darken($color-accent, 10%);
-$deep-dark-accent: darken($color-accent, 50%);
+$dark-accent: color.adjust($color-accent, $lightness: -10%);
+$deep-dark-accent: color.adjust($color-accent, $lightness: -50%);
 $color-text: $deep-dark-accent;
 
-@if lightness($color-accent) <20% {
+@if color.channel($color-accent, "lightness", $space: hsl) < 20% {
   $dark-accent: $color-accent;
   $deep-dark-accent: $color-accent;
   $color-text: $deep-dark-accent;

--- a/src/scss/base/_generic.scss
+++ b/src/scss/base/_generic.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../variables" as *;
+
 /**
  * Generic
  */
@@ -100,7 +103,7 @@ a {
   color: $color-accent;
   text-decoration: none;
   &:hover {
-    color: darken($color-accent, 10%);
+    color: color.adjust($color-accent, $lightness: -10%);
     text-underline-position: under;
   }
 }

--- a/src/scss/init.scss
+++ b/src/scss/init.scss
@@ -1,4 +1,4 @@
 @charset "UTF-8";
 
-@import "variables";
-@import "base";
+@use "variables" as *;
+@use "base";


### PR DESCRIPTION
## Summary
- Migrate all `.scss` files from deprecated `@import` to `@use`/`@forward` syntax
- Replace deprecated `darken()` with `color.adjust($lightness: ...)` 
- Replace deprecated `lightness()` with `color.channel($channel: "lightness")`
- Override `sass-loader` to v16 to fix legacy JS API deprecation warnings

## Test plan
- [ ] `gatsby build` completes without Sass deprecation warnings from project code
- [x] Verify sidebar styling (hover effects, active states) looks correct
- [x] Verify table of contents styling works
- [x] Verify overall site styling matches the previous version